### PR TITLE
Adding support for hackage servers other than hackage.haskell.org

### DIFF
--- a/src/Arguments.hs
+++ b/src/Arguments.hs
@@ -13,7 +13,7 @@ data Arguments
     | Send {repo :: FilePath, patch :: FilePath}
     | Apply {patch :: FilePath}
     | Tag
-    | Docs {username :: String}
+    | Docs {username :: String, host :: String}
 
     | Travis {wait :: Double}
  
@@ -42,7 +42,7 @@ arguments = cmdArgsMode $ modes
           &= help "Create a cabal sdist with extra checks"
     ,Tag {} &= help "Tag the repo, after a release"
     ,Check
-    ,Docs {username = "NeilMitchell"}
+    ,Docs {username = "NeilMitchell", host = "https://hackage.haskell.org"}
     ,Travis {wait = 0 &= help "Time to wait after each wget request"}
     ,Test {install = False &= help "Install after building"}
     ]

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -113,7 +113,7 @@ run Docs{..} = Just $ do
               "-H \"Content-Encoding: gzip\" " ++
               "-u " ++ username ++ " " ++
               "--data-binary \"@" ++ dir ++ "/" ++ name ++ "-" ++ ver ++ "-docs.tar.gz\" " ++
-              "https://hackage.haskell.org/package/" ++ name ++ "-" ++ ver ++ "/docs"
+              host ++ "/package/" ++ name ++ "-" ++ ver ++ "/docs"
 
 run _ = Nothing
 


### PR DESCRIPTION
Be able to use the program with other Hackage servers but still have it default to the main Hackage server.
