### PR TITLE
Make html files writable before patching

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -130,6 +130,7 @@ run Docs{..} = Just $ do
         system_ $ "cp -R dist/doc/html/" ++ name ++ " \"" ++ dir ++ "/" ++ name ++ "-" ++ ver ++ "-docs\""
         files <- listFilesRecursive dir
         forM_ files $ \file -> when (takeExtension file == ".html") $ do
+            system_ $ "chmod u+w " ++ (dir </> file)
             src <- readFileBinary' $ dir </> file
             src <- return $ filter (/= '\r') src -- filter out \r, due to CPP bugs
             src <- return $ fixFileLinks $ fixHashT src


### PR DESCRIPTION
Haddock makes them read-only apparently