### PR TITLE
Include --html flag for haddock in doc generation

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -123,7 +123,7 @@ run Docs{..} = Just $ do
     src <- readCabal
     let ver = extractCabal "version" src
     let name = extractCabal "name" src
-    system_ $ "cabal haddock --hoogle --hyperlink-source " ++
+    system_ $ "cabal haddock --hoogle --html --hyperlink-source " ++
           "--contents-location=/package/" ++ name
     withTempDir $ \dir -> do
         system_ $ "cp -R dist/doc/html/" ++ name ++ " \"" ++ dir ++ "/" ++ name ++ "-" ++ ver ++ "-docs\""


### PR DESCRIPTION
For some reason, "neil docs" was only creating the hoogle output. This fixed it.