### PR TITLE
Make AppVeyor badge URL compatible with more repos.

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -274,8 +274,8 @@ checkReadme = do
              "(https://www.stackage.org/package/" ++ name ++ ")"
             ,"[![Linux Build Status](https://img.shields.io/travis/" ++ qname ++ ".svg?label=Linux%20build)]" ++
              "(https://travis-ci.org/" ++ qname ++ ")"
-            ,"[![Windows Build Status](https://img.shields.io/appveyor/ci/ndmitchell/" ++ name ++ ".svg?label=Windows%20build)]" ++
-             "(https://ci.appveyor.com/project/ndmitchell/" ++ name ++ ")"
+            ,"[![Windows Build Status](https://img.shields.io/appveyor/ci/" ++ qname ++ ".svg?label=Windows%20build)]" ++
+             "(https://ci.appveyor.com/project/" ++ qname ++ ")"
             ,"[![Build Status](https://img.shields.io/travis/" ++ qname ++ ".svg)]" ++
              "(https://travis-ci.org/" ++ qname ++ ")"
             ]


### PR DESCRIPTION
Previously it assumed the repo was a project by @ndmitchell.

See https://github.com/malcolmwallace/cpphs/issues/9#issuecomment-284539817