### PR TITLE
Allow specifying any GitHub user and commit in travis.sh

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -4,6 +4,17 @@
 set -e # exit on errors
 set -x # echo each line
 
+GITHUB_USER=$1
+COMMIT=$2
+
+if [ -z "$GITHUB_USER" ]; then
+    GITHUB_USER=ndmitchell
+fi
+
+if [ -z "$COMMIT" ]; then
+    COMMIT=master
+fi
+
 retry(){ "$@" || (sleep 30s && "$@") || (sleep 30s && "$@"); }
 timer(){
     set +x;
@@ -70,8 +81,8 @@ if [ "$GHC_HEAD" = "1" ] && [ "$FAIL" = "1" ]; then
     fi
 fi
 
-retry git clone https://github.com/ndmitchell/neil .neil
-(cd .neil && retry cabal install --flags=small)
+retry git clone -n "https://github.com/$GITHUB_USER/neil" .neil
+(cd .neil && git checkout $COMMIT && retry cabal install --flags=small)
 
 if [ -e travis.hs ]; then
     # ensure that reinstalling this package won't break the test script


### PR DESCRIPTION
I would like to be able to use `neil` from my own GitHub repository.  Furthermore I would like my packages to be able to specify a specific commit or branch to test with, firstly so that they don't have to be updated in lockstep with `master` and secondly to allow myself to test different versions of `neil`.

`checkTravis` expects a `script` stanza like this

```
- curl -sL https://raw.github.com/tomjaguarpaw/neil/<commit>/travis.sh | sh -s tomjaguarpaw <commit>
```

and it just checks that GitHub user name and commit match on both sides of the pipe.