### PR TITLE
Update tested-with to include 8.6.2

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -17,7 +17,7 @@ import Arguments
 import Prelude
 
 -- | GHC releases I test with
-ghcReleases = ["7.4.2","7.6.3","7.8.4","7.10.3","8.0.2","8.2.2","8.4.4","8.6.1"]
+ghcReleases = ["7.4.2","7.6.3","7.8.4","7.10.3","8.0.2","8.2.2","8.4.4","8.6.2"]
 
 -- | The next version of GHC that has not yet been released
 --   (might test it in Travis, but won't be in the tested-with)


### PR DESCRIPTION
The `tested-with` test is outdated. 8.6.2 is the current release of the
8.6 branch of GHC.
