### PR TITLE
Add one 'X' to the mktemp template

### DIFF
--- a/misc/run.sh
+++ b/misc/run.sh
@@ -32,7 +32,7 @@ echo Downloading and running $PACKAGE...
 RELEASES=$(curl --silent --show-error https://github.com/ndmitchell/$PACKAGE/releases)
 URL=https://github.com/$(echo $RELEASES | grep -o '\"[^\"]*-x86_64-'$OS$ESCEXT'\"' | sed s/\"//g | head -n1)
 VERSION=$(echo $URL | sed -n 's@.*-\(.*\)-x86_64-'$OS$ESCEXT'@\1@p')
-TEMP=$(mktemp -d .$PACKAGE-XXXXX)
+TEMP=$(mktemp -d .$PACKAGE-XXXXXX)
 
 cleanup(){
     rm -r $TEMP


### PR DESCRIPTION
busybox's mktemp requires the template to end with at least six Xs.
Closes: #43 