### PR TITLE
Use new cabal-version format

### DIFF
--- a/neil.cabal
+++ b/neil.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >= 1.18
+cabal-version:      1.18
 build-type:         Simple
 name:               neil
 version:            0.12


### PR DESCRIPTION
This seems to be the way cabal prefers to do version numbers these days.