### PR TITLE
Add workflow_dispatch GitHub actions trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
   - cron:  '0 3 * * 6' # 3am Saturday
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Can we add this? It adds the ability to trigger a workflow run by clicking a button on the webpage rather than having to push a new commit.