### PR TITLE
feat: `run.sh` can now accept release version

### DIFF
--- a/misc/run.sh
+++ b/misc/run.sh
@@ -11,7 +11,7 @@ fi
 shift
 
 # The PACKAGE_ARG can optionally have a release version separated by the @ character.
-if [[ $PACKAGE_ARG == *'@'* ]]; then
+if [[ "$PACKAGE_ARG" == *'@'* ]]; then
     PACKAGE=$(echo "$PACKAGE_ARG" | cut -d'@' -f1)
     RELEASE_VERSION=$(echo "$PACKAGE_ARG" | cut -d'@' -f2)
 else 

--- a/misc/run.sh
+++ b/misc/run.sh
@@ -11,13 +11,16 @@ fi
 shift
 
 # The PACKAGE_ARG can optionally have a release version separated by the @ character.
-if [[ "$PACKAGE_ARG" == *'@'* ]]; then
-    PACKAGE=$(echo "$PACKAGE_ARG" | cut -d'@' -f1)
-    RELEASE_VERSION=$(echo "$PACKAGE_ARG" | cut -d'@' -f2)
-else 
-    PACKAGE="$PACKAGE_ARG"
-    RELEASE_VERSION=""
-fi
+case ${PACKAGE_ARG} in
+    *@*)
+        PACKAGE=$(echo "$PACKAGE_ARG" | cut -d'@' -f1)
+        RELEASE_VERSION=$(echo "$PACKAGE_ARG" | cut -d'@' -f2)
+        ;;
+    *)
+        PACKAGE="$PACKAGE_ARG"
+        RELEASE_VERSION=""
+        ;;
+esac
 
 case "$(uname)" in
     "Darwin")


### PR DESCRIPTION
Resolves https://github.com/ndmitchell/neil/issues/47

Backward compatibility of the `run.sh` doesn't change, it can still be run the following:

`curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/run.sh | sh -s -- hlint .`

But now, optionally a version of the package can be specified (otherwise latest is picked):

`curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/run.sh | sh -s -- hlint@3.4.1 .`

NOTE:
When there's a minor version, that one is picked instead.
I.e. if I would specify `hlint@3.4` the `hlint@3.4.1` would be picked