### PR TITLE
update badges list in checkReadme

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -308,7 +308,7 @@ checkReadme = do
              "(https://hackage.haskell.org/package/" ++ name ++ ")"
             ,"[![Stackage version](https://www.stackage.org/package/" ++ name ++ "/badge/nightly?label=Stackage)]" ++
              "(https://www.stackage.org/package/" ++ name ++ ")"
-            ,"[![Build status](https://img.shields.io/github/workflow/status/" ++ github ++ "/ci/master.svg)]" ++
+            ,"[![Build status](https://img.shields.io/github/actions/workflow/status/" ++ github ++ "/ci.yml?branch=master)]" ++
              "(https://github.com/" ++ github ++ "/actions)"
             ]
     let line1 = head $ src ++ [""]


### PR DESCRIPTION
this hlint PR https://github.com/ndmitchell/hlint/pull/1530 changed a badge which causes hlint fail to CI. hopefully this fixes it.